### PR TITLE
Fix apiUrl never being set when logging in with username and password

### DIFF
--- a/app/src/_util/providers/auth-provider.ts
+++ b/app/src/_util/providers/auth-provider.ts
@@ -41,6 +41,7 @@ export const authProvider: AuthProvider = {
             if(res.ok) {
                 const resJson = await res.json()
                 setApiToken(resJson.data.attributes.token)
+                setApiUrl(`${domain}`)
                 return {success: true, redirectTo: "/"}
             }
         }


### PR DESCRIPTION
I tried keygeny and noticed, that the login with username and password did not work correctly.

While the login itself work fine, I could not retrieve any licenses, policies or users.

The error message on the javascript console was:
```
chunk-6H5N7CVH.js?v=ad83785c:4438 TypeError: Failed to construct 'URL': Invalid URL
    at getList (data-provider.ts:63:21)
    at Object.queryFn (chunk-6H5N7CVH.js?v=ad83785c:8940:12)
    at Object.fetchFn [as fn] (chunk-6H5N7CVH.js?v=ad83785c:4407:27)
    at run (chunk-6H5N7CVH.js?v=ad83785c:4072:31)
    at chunk-6H5N7CVH.js?v=ad83785c:4100:11
 ```
 
As far as I can tell from a quick look into the soruce code, the apiUrl was never set on the appState,
for the login with username and password.

This PR just adds the missing call.